### PR TITLE
fix: add `visible` parameter to `get_expenses` call

### DIFF
--- a/src/splitwise.js
+++ b/src/splitwise.js
@@ -120,6 +120,7 @@ const METHODS = {
       'updated_before',
       'limit',
       'offset',
+      'visible',
     ],
   },
   GET_EXPENSE: {


### PR DESCRIPTION
Since they introduced deleting and undeleting expenses, this library always returns all expenses unless you set `visible=true`.