### PR TITLE
Add option to split expense equally

### DIFF
--- a/src/splitwise.js
+++ b/src/splitwise.js
@@ -148,6 +148,7 @@ const METHODS = {
       'currency_code',
       'category_id',
       'users',
+      'split_equally'
     ],
   },
   UPDATE_EXPENSE: {


### PR DESCRIPTION
The Splitwise API [create_expense endpoint](https://dev.splitwise.com/#tag/expenses/paths/~1create_expense/post) supports a `split_equally` property which, when `true`, obviates the need for manually specifying users and amounts. (Manually specifying amounts is error-prone due to rounding.) This is perhaps the most common use case so it makes sense for this library to support it.