### PR TITLE
Add currency_code to update expense

### DIFF
--- a/src/splitwise.js
+++ b/src/splitwise.js
@@ -168,6 +168,7 @@ const METHODS = {
       'date',
       'category_id',
       'users',
+      'currency_code',
     ],
   },
   DELETE_EXPENSE: {


### PR DESCRIPTION
Added missing `currency_code` param to update expense.

Link to docs: https://dev.splitwise.com/#tag/expenses/paths/~1update_expense~1{id}/post